### PR TITLE
prevent adding duplicate css imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4094,6 +4094,17 @@
         "flatted": "^2.0.0",
         "rimraf": "2.6.3",
         "write": "1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flatted": {
@@ -9364,9 +9375,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
       "dev": true,
       "requires": {
         "glob": "^7.1.3"

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "scripts": {
     "lint": "eslint ./",
     "test": "jest",
+    "test:clean": "rm -f test/plugin/fixtures/*/output.js",
+    "test:update": "nrun test:clean && nrun test -u",
     "spellcheck": "yaspeller-ci *.md",
-    "clean-test-output": "rm -f test/plugin/fixtures/*/output.js",
-    "update-test-output": "nrun clean-test-output && nrun test",
+    "dev": "nrun build --watch --verbose",
     "build": "babel src --out-dir lib"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -6,11 +6,12 @@
   "scripts": {
     "lint": "eslint ./",
     "test": "jest",
-    "test:clean": "rm -f test/plugin/fixtures/*/output.js",
+    "test:clean": "rimraf test/plugin/fixtures/*/output.js",
     "test:update": "nrun test:clean && nrun test -u",
     "spellcheck": "yaspeller-ci *.md",
     "dev": "nrun build --watch --verbose",
-    "build": "babel src --out-dir lib"
+    "clean": "rimraf lib coverage",
+    "build": "nrun clean && babel src --out-dir lib"
   },
   "files": [
     "lib"
@@ -49,6 +50,7 @@
     "jest": "^25.1.0",
     "lint-staged": "^10.0.7",
     "nrun": "^1.0.0",
+    "rimraf": "^3.0.2",
     "yaspeller-ci": "^1.0.2"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,16 @@ import { parse } from '@babel/parser';
 import { addNamed } from '@babel/helper-module-imports';
 import { findConditionalBlocks, createExpression } from './helpers';
 
+let cssHint;
+
 export default function ({ types: t }) {
   return {
     name: 'styled-props-conditions',
 
     visitor: {
+      Program() {
+        cssHint = null;
+      },
       TaggedTemplateExpression(path) {
         const { quasis } = path.node.quasi;
         const quasisRaws = quasis.map(({ value }) => value.raw);
@@ -16,7 +21,9 @@ export default function ({ types: t }) {
 
         if (!conditionalBlocks.length) return;
 
-        const cssHint = addNamed(path, 'css', 'styled-components');
+        if (!cssHint) {
+          cssHint = addNamed(path, 'css', 'styled-components');
+        }
 
         conditionalBlocks.forEach((conditionalBlock) => {
           const {

--- a/test/plugin/fixtures/ensureSingleCssImport/code.js
+++ b/test/plugin/fixtures/ensureSingleCssImport/code.js
@@ -1,0 +1,7 @@
+styled.div`
+  @if a {}
+`;
+
+styled.button`
+  @if a {}
+`;

--- a/test/plugin/fixtures/ensureSingleCssImport/output.js
+++ b/test/plugin/fixtures/ensureSingleCssImport/output.js
@@ -1,0 +1,7 @@
+import { css as _css } from "styled-components";
+styled.div`
+  ${({ a }) => a && _css``}
+`;
+styled.button`
+  ${({ a }) => a && _css``}
+`;

--- a/test/plugin/fixtures/nestedConditions/output.js
+++ b/test/plugin/fixtures/nestedConditions/output.js
@@ -1,4 +1,3 @@
-import { css as _css2 } from "styled-components";
 import { css as _css } from "styled-components";
 styled.div`
   color: green;
@@ -27,21 +26,21 @@ styled.div`
 
   ${({ a }) =>
     a &&
-    _css2`
+    _css`
     ${a}
     color: grey;
     ${a}
 
     ${({ b }) =>
       b &&
-      _css2`
+      _css`
       ${a}
       color: red;
       ${a}
 
       ${({ c }) =>
         c === func(c) + "something" &&
-        _css2`
+        _css`
         ${a}
         display: block;
         ${a}

--- a/test/plugin/fixtures/plainConditions/output.js
+++ b/test/plugin/fixtures/plainConditions/output.js
@@ -1,4 +1,3 @@
-import { css as _css2 } from "styled-components";
 import { css as _css } from "styled-components";
 styled.div`
   ${({ a }) =>
@@ -24,7 +23,7 @@ styled.button`
 
   ${({ a }) =>
     a &&
-    _css2`
+    _css`
     ${a + b}
 
     color: green;


### PR DESCRIPTION
This plugin adds follow import
```js
import { css as _css } from "styled-components";
```

for each `TaggedTemplateExpression` containing `@if {}` blocks. In this pull request the plugin adds a single `import` per file.